### PR TITLE
Show hidden chapters semi-transparent in editor mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -178,6 +178,16 @@ footer {
     display: none;
 }
 
+/* Hidden chapters */
+.hidden-item {
+    display: none;
+}
+
+body.editor-mode .hidden-item {
+    display: block;
+    opacity: 0.5;
+}
+
 .edit-btn {
     margin-left: 5px;
     font-size: 0.8em;

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
+    assignNavIds();
+    loadHiddenItems();
+
     const toggles = document.querySelectorAll('.category-toggle');
     toggles.forEach(toggle => {
         toggle.addEventListener('click', () => {
@@ -28,6 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (loginArea) loginArea.classList.add('hidden');
         const toolbar = document.getElementById('edit-toolbar');
         if (toolbar) toolbar.classList.remove('hidden');
+        document.body.classList.add('editor-mode');
         const mainContent = document.getElementById('main-content');
         if (mainContent) {
             mainContent.contentEditable = 'true';
@@ -40,6 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
         items.forEach(li => {
             const target = li.querySelector('.category-toggle, a');
             if (!target) return;
+            const id = li.dataset.id;
 
             const renameBtn = document.createElement('button');
             renameBtn.textContent = 'Renommer';
@@ -50,16 +55,12 @@ document.addEventListener('DOMContentLoaded', function() {
             });
 
             const hideBtn = document.createElement('button');
-            hideBtn.textContent = 'Cacher';
+            hideBtn.textContent = li.classList.contains('hidden-item') ? 'Afficher' : 'Cacher';
             hideBtn.className = 'edit-btn';
             hideBtn.addEventListener('click', () => {
-                if (li.style.display === 'none') {
-                    li.style.display = '';
-                    hideBtn.textContent = 'Cacher';
-                } else {
-                    li.style.display = 'none';
-                    hideBtn.textContent = 'Afficher';
-                }
+                const isHidden = li.classList.toggle('hidden-item');
+                hideBtn.textContent = isHidden ? 'Afficher' : 'Cacher';
+                updateHiddenItems(id, isHidden);
             });
 
             const deleteBtn = document.createElement('button');
@@ -67,12 +68,38 @@ document.addEventListener('DOMContentLoaded', function() {
             deleteBtn.className = 'edit-btn';
             deleteBtn.addEventListener('click', () => {
                 li.remove();
+                updateHiddenItems(id, false);
             });
 
             li.appendChild(renameBtn);
             li.appendChild(hideBtn);
             li.appendChild(deleteBtn);
         });
+    }
+
+    function assignNavIds() {
+        const items = document.querySelectorAll('#side-nav li');
+        items.forEach((li, index) => {
+            li.dataset.id = index.toString();
+        });
+    }
+
+    function loadHiddenItems() {
+        const hidden = JSON.parse(localStorage.getItem('hiddenItems') || '[]');
+        hidden.forEach(id => {
+            const li = document.querySelector(`#side-nav li[data-id="${id}"]`);
+            if (li) li.classList.add('hidden-item');
+        });
+    }
+
+    function updateHiddenItems(id, hide) {
+        let hidden = JSON.parse(localStorage.getItem('hiddenItems') || '[]');
+        if (hide) {
+            if (!hidden.includes(id)) hidden.push(id);
+        } else {
+            hidden = hidden.filter(item => item !== id);
+        }
+        localStorage.setItem('hiddenItems', JSON.stringify(hidden));
     }
 
     const insertTableBtn = document.getElementById('insert-table');


### PR DESCRIPTION
## Summary
- Reveal hidden chapters as semi-transparent entries in editor mode while keeping them hidden in normal mode.
- Store hidden chapter state in `localStorage` so normal mode hides them, but editor mode can re-enable them.

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5762dc49c83328207719e79b57a30