### PR TITLE
Add Netlify function to commit wiki updates

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,10 +1,3 @@
-const GITHUB_CONFIG = {
-    owner: 'Zhaal', // Remplacer par l'utilisateur GitHub
-    repo: 'JDR',   // Remplacer par le nom du dépôt
-    filePath: 'data/wiki.json',
-    token: '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'       // Ajouter un token GitHub avec droits de commit
-};
-
 document.addEventListener('DOMContentLoaded', async function() {
     await loadSavedWiki();
     assignNavIds();
@@ -237,11 +230,6 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
 
     async function saveWikiOnline() {
-        if (!GITHUB_CONFIG.token) {
-            console.warn('Token GitHub manquant, sauvegarde en ligne ignorée.');
-            return;
-        }
-
         const sideNav = document.getElementById('side-nav').cloneNode(true);
         sideNav.querySelectorAll('.edit-btn').forEach(btn => btn.remove());
         const main = document.getElementById('main-content').cloneNode(true);
@@ -252,33 +240,14 @@ document.addEventListener('DOMContentLoaded', async function() {
             hiddenItems: JSON.parse(localStorage.getItem('hiddenItems') || '[]')
         };
 
-        const { owner, repo, filePath, token } = GITHUB_CONFIG;
-        const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`;
-
-        let sha;
-        const getResp = await fetch(apiUrl, {
-            headers: { Authorization: `Bearer ${token}` }
-        });
-        if (getResp.ok) {
-            const info = await getResp.json();
-            sha = info.sha;
-        }
-
-        const putResp = await fetch(apiUrl, {
-            method: 'PUT',
-            headers: {
-                Authorization: `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                message: 'Mise à jour du wiki',
-                content: btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2)))) ,
-                sha
-            })
+        const resp = await fetch('/.netlify/functions/saveWiki', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
         });
 
-        if (!putResp.ok) {
-            throw new Error('Échec de la sauvegarde GitHub');
+        if (!resp.ok) {
+            throw new Error('Échec de la sauvegarde en ligne');
         }
     }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[functions]
+directory = "netlify/functions"

--- a/netlify/functions/saveWiki.js
+++ b/netlify/functions/saveWiki.js
@@ -1,0 +1,51 @@
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return { statusCode: 500, body: 'Missing GITHUB_TOKEN' };
+  }
+
+  const data = JSON.parse(event.body || '{}');
+  const content = Buffer.from(JSON.stringify(data, null, 2)).toString('base64');
+
+  const owner = 'Zhaal';
+  const repo = 'JDR';
+  const filePath = 'data/wiki.json';
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`;
+
+  let sha;
+  const getRes = await fetch(apiUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'netlify-function'
+    }
+  });
+  if (getRes.ok) {
+    const info = await getRes.json();
+    sha = info.sha;
+  }
+
+  const putRes = await fetch(apiUrl, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'netlify-function'
+    },
+    body: JSON.stringify({
+      message: 'Mise à jour wiki.json',
+      content,
+      sha
+    })
+  });
+
+  if (!putRes.ok) {
+    const errorBody = await putRes.text();
+    return { statusCode: putRes.status, body: errorBody };
+  }
+
+  return { statusCode: 200, body: 'Sauvegarde effectuée' };
+};


### PR DESCRIPTION
## Summary
- Remove client-side GitHub token usage and call Netlify function for wiki saves
- Add Netlify `saveWiki` function that updates `data/wiki.json` via GitHub API
- Configure Netlify functions directory

## Testing
- `node --check js/main.js`
- `node --check netlify/functions/saveWiki.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b581568f5483329488ac813243e506