### PR TITLE
Use token scheme for GitHub API in Netlify function

### DIFF
--- a/netlify/functions/saveWiki.js
+++ b/netlify/functions/saveWiki.js
@@ -19,7 +19,7 @@ exports.handler = async (event) => {
   let sha;
   const getRes = await fetch(apiUrl, {
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `token ${token}`,
       'User-Agent': 'netlify-function'
     }
   });
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
   const putRes = await fetch(apiUrl, {
     method: 'PUT',
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `token ${token}`,
       'Content-Type': 'application/json',
       'User-Agent': 'netlify-function'
     },


### PR DESCRIPTION
## Summary
- send Authorization header using `token` prefix for GitHub API calls in `saveWiki`

## Testing
- `node --check netlify/functions/saveWiki.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5841030188332a0ca5d380c7d095c