### PR TITLE
Feat: Add interactive editing modes to the navigation editor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -348,3 +348,86 @@ body.editor-mode #side-nav li:not(.hidden-item) > a {
     background-color: #6c757d;
     cursor: not-allowed;
 }
+
+#editor-controls .action-buttons button.active {
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+}
+
+/* --- Edit Mode Styles --- */
+
+.edit-icon {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    margin-right: 8px;
+    cursor: pointer;
+    vertical-align: middle;
+    text-align: center;
+    font-weight: bold;
+    line-height: 20px;
+}
+
+/* Delete Icon */
+.delete-icon {
+    background-color: red;
+    color: yellow;
+    animation: flash-delete 1s infinite;
+}
+
+@keyframes flash-delete {
+    0%, 100% { color: yellow; }
+    50% { color: black; }
+}
+
+/* Rename Icon */
+.rename-icon {
+    background-color: blue;
+    color: white;
+    animation: flash-rename 1s infinite;
+}
+
+@keyframes flash-rename {
+    0%, 100% { color: white; }
+    50% { color: lightgreen; }
+}
+
+/* Hide/Show Icon */
+.hide-icon {
+    border-radius: 50%;
+}
+
+.hide-icon.is-visible {
+    background-color: green;
+}
+
+.hide-icon.is-hidden {
+    background-color: yellow;
+}
+
+.hide-icon .icon-eye {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    margin-top: 3px;
+}
+
+.hide-icon.is-visible .icon-eye {
+    background-color: white;
+    animation: flash-eye-visible 1s infinite;
+}
+
+.hide-icon.is-hidden .icon-eye {
+    background-color: black;
+    animation: flash-eye-hidden 1s infinite;
+}
+
+@keyframes flash-eye-visible {
+    0%, 100% { background-color: white; }
+    50% { background-color: lightgray; }
+}
+
+@keyframes flash-eye-hidden {
+    0%, 100% { background-color: black; }
+    50% { background-color: dimgray; }
+}

--- a/index.html
+++ b/index.html
@@ -23,40 +23,47 @@
             <div id="editor-panel" class="hidden">
                 <h3>Éditeur de Navigation</h3>
                 <div id="editor-controls">
-                    <div class="control-group">
-                        <label for="chapter-select">Chapitre:</label>
-                        <select id="chapter-select">
-                            <option value="">Nouveau Chapitre</option>
-                        </select>
+                    <div id="item-selection-controls">
+                        <div class="control-group">
+                            <label for="chapter-select">Chapitre:</label>
+                            <select id="chapter-select">
+                                <option value="">Nouveau Chapitre</option>
+                            </select>
+                        </div>
+                        <div class="control-group">
+                            <label for="subchapter-select">Sous-chapitre:</label>
+                            <select id="subchapter-select" disabled>
+                                <option value="">Nouveau Sous-chapitre</option>
+                            </select>
+                        </div>
+                        <div class="control-group">
+                            <label for="item-select">Élément:</label>
+                            <select id="item-select" disabled>
+                                <option value="">Nouvel Élément</option>
+                            </select>
+                        </div>
                     </div>
-                    <div class="control-group">
-                        <label for="subchapter-select">Sous-chapitre:</label>
-                        <select id="subchapter-select" disabled>
-                            <option value="">Nouveau Sous-chapitre</option>
-                        </select>
+                    <div id="add-item-controls">
+                        <div class="control-group">
+                            <label for="item-type-select">Type (si nouveau sous-chapitre):</label>
+                            <select id="item-type-select" disabled>
+                                <option value="sub-chapter">Sous-chapitre</option>
+                                <option value="item">Élément</option>
+                            </select>
+                        </div>
+                        <div class="control-group">
+                            <label for="item-name">Nom:</label>
+                            <input type="text" id="item-name" placeholder="Nom de l'élément">
+                        </div>
+                        <div class="action-buttons">
+                            <button id="add-btn" disabled>Ajouter</button>
+                        </div>
                     </div>
-                    <div class="control-group">
-                        <label for="item-select">Élément:</label>
-                        <select id="item-select" disabled>
-                            <option value="">Nouvel Élément</option>
-                        </select>
-                    </div>
-                    <div class="control-group">
-                        <label for="item-type-select">Type (si sous-chapitre est vide):</label>
-                        <select id="item-type-select" disabled>
-                            <option value="sub-chapter">Sous-chapitre</option>
-                            <option value="item">Élément</option>
-                        </select>
-                    </div>
-                    <div class="control-group">
-                        <label for="item-name">Nom:</label>
-                        <input type="text" id="item-name" placeholder="Nom de l'élément">
-                    </div>
+                    <hr>
                     <div class="action-buttons">
-                        <button id="add-btn">Ajouter</button>
-                        <button id="rename-btn" disabled>Renommer</button>
-                        <button id="delete-btn" disabled>Supprimer</button>
-                        <button id="toggle-hide-btn" disabled>Cacher/Afficher</button>
+                        <button id="rename-btn">Renommer</button>
+                        <button id="delete-btn">Supprimer</button>
+                        <button id="toggle-hide-btn">Cacher/Afficher</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit refactors the navigation editor to introduce a more interactive and intuitive editing experience.

Key changes:
- Introduces three editing modes: Delete, Rename, and Hide/Show.
- When a mode is activated, interactive icons appear next to each navigation item, allowing for direct manipulation.
- Adds CSS for the new icons, including colors, shapes, and flashing animations as requested.
- The main editor panel is hidden during editing modes to focus the user's attention.
- The previous workflow of selecting an item from dropdowns to edit is replaced by this more direct approach.