### PR TITLE
Fix: Align editor icons on the same line as text

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
                 const target = li.querySelector(':scope > a, :scope > .category-toggle');
                 if (target) {
-                    li.insertBefore(icon, target);
+                    target.prepend(icon);
                 }
             });
         }


### PR DESCRIPTION
The editor icons (delete, rename, hide) were appearing on a separate line above the navigation item text. This was because the text element (`a` or `span.category-toggle`) was styled as a block-level element, forcing a line break.

This commit fixes the issue by changing the DOM manipulation logic in `js/main.js`. Instead of inserting the icon before the text element within the `<li>`, the icon is now prepended as the first child of the text element itself. This places the icon and text within the same block formatting context, ensuring they render on the same line.