### PR TITLE
Refactor: Rework the navigation editor panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -316,17 +316,58 @@ body.editor-mode #side-nav li:not(.hidden-item) > a {
     margin-top: 20px;
 }
 
-#editor-controls .action-buttons button {
-    padding: 10px 15px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 1em;
+#editor-panel .action-buttons {
+    display: flex;
+    justify-content: space-around; /* Better for 3 buttons */
+    margin-bottom: 15px;
 }
 
-#editor-controls #add-btn {
-    background-color: #28a745;
+#editor-panel button {
+    padding: 10px 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    background-color: #f0f0f0;
+    transition: background-color 0.2s;
+}
+
+#editor-panel button:hover {
+    background-color: #e0e0e0;
+}
+
+#editor-panel button:disabled {
+    background-color: #e9ecef;
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+#editor-panel #create-edit-btn {
+    width: 100%;
+    padding: 12px;
+    font-size: 1em;
+    font-weight: bold;
+    background-color: #007bff;
     color: white;
+    border: none;
+}
+
+#editor-panel #create-edit-btn:hover {
+    background-color: #0069d9;
+}
+
+#editor-workflow-view {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#editor-workflow-view h4 {
+    margin: 0;
+    font-size: 1.1em;
+    text-align: center;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 10px;
 }
 
 #editor-controls #rename-btn {

--- a/index.html
+++ b/index.html
@@ -23,49 +23,17 @@
             </div>
             <div id="editor-panel" class="hidden">
                 <h3>Éditeur de Navigation</h3>
-                <div id="editor-controls">
-                    <div id="item-selection-controls">
-                        <div class="control-group">
-                            <label for="chapter-select">Chapitre:</label>
-                            <select id="chapter-select">
-                                <option value="">Nouveau Chapitre</option>
-                            </select>
-                        </div>
-                        <div class="control-group">
-                            <label for="subchapter-select">Sous-chapitre:</label>
-                            <select id="subchapter-select" disabled>
-                                <option value="">Nouveau Sous-chapitre</option>
-                            </select>
-                        </div>
-                        <div class="control-group">
-                            <label for="item-select">Élément:</label>
-                            <select id="item-select" disabled>
-                                <option value="">Nouvel Élément</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div id="add-item-controls">
-                        <div class="control-group">
-                            <label for="item-type-select">Type (si nouveau sous-chapitre):</label>
-                            <select id="item-type-select" disabled>
-                                <option value="sub-chapter">Sous-chapitre</option>
-                                <option value="item">Élément</option>
-                            </select>
-                        </div>
-                        <div class="control-group">
-                            <label for="item-name">Nom:</label>
-                            <input type="text" id="item-name" placeholder="Nom de l'élément">
-                        </div>
-                        <div class="action-buttons">
-                            <button id="add-btn" disabled>Ajouter</button>
-                        </div>
-                    </div>
-                    <hr>
+                <div id="editor-main-view">
                     <div class="action-buttons">
                         <button id="rename-btn">Renommer</button>
                         <button id="delete-btn">Supprimer</button>
                         <button id="toggle-hide-btn">Cacher/Afficher</button>
                     </div>
+                    <hr>
+                    <button id="create-edit-btn">Créer ou Editer un élément</button>
+                </div>
+                <div id="editor-workflow-view" class="hidden">
+                    <!-- This will be populated by JavaScript -->
                 </div>
             </div>
         </header>
@@ -73,6 +41,7 @@
             <aside id="sidebar">
                 <nav id="side-nav">
                     <h3>POUR LES JOUEURS…</h3>
+                    <button id="edit-menu-btn" class="hidden">Editer le menu</button>
                     <ul>
                         <li>
                             <span class="category-toggle">Règles de base</span>


### PR DESCRIPTION
This commit completely overhauls the navigation editor panel based on user feedback.

The previous dropdown-based system for creating new navigation items has been replaced with a guided, button-driven workflow. The user is now presented with clear choices for creating or editing chapters, sub-chapters, and items, which makes the process more intuitive.

Key changes:
- A new 'Editer le menu' button is added to the sidebar, which toggles the visibility of the editor panel.
- The editor panel UI is restructured to support the new workflow.
- The JavaScript logic in `js/main.js` is significantly refactored to dynamically render the workflow steps.
- Existing functionality for renaming, deleting, and hiding/showing items is preserved and integrated into the new panel.
- New CSS styles are added to support the redesigned panel.
- A bug in the rename functionality that caused duplicate icons has been fixed.