### PR TITLE
Feat: Implement per-page editing and UI cleanup

### DIFF
--- a/data/wiki.json
+++ b/data/wiki.json
@@ -555,6 +555,8 @@
       ]
     }
   ],
-  "mainContent": "<h2>Bienvenue sur le wiki de Transcendant !</h2>test<p><br></p><p><br></p>\n            ",
+  "pages": {
+    "1": "<h2>Bienvenue sur le wiki de Transcendant !</h2>test<p><br></p><p><br></p>\n            "
+  },
   "hiddenItems": []
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
                         <button id="toggle-hide-btn">Cacher/Afficher</button>
                     </div>
                     <hr>
-                    <button id="create-edit-btn">Créer ou Editer un élément</button>
                 </div>
                 <div id="editor-workflow-view" class="hidden">
                     <!-- This will be populated by JavaScript -->


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Per-page editing:** The application now supports a separate content page for each navigation item.
    - The data structure in `data/wiki.json` was changed from a single `mainContent` to a `pages` object, keyed by item ID.
    - The JavaScript logic was updated to load and save page content dynamically based on the selected navigation item.

2.  **UI Cleanup:** Redundant buttons in the 'Éditeur de Navigation' have been removed as requested.
    - The 'Créer ou édité un élément' button has been removed from the main editor view.
    - The 'Retour' button has been removed from the editor workflow view.