### PR TITLE
Feat: Implement per-page editing and new editor UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
                         <button id="toggle-hide-btn">Cacher/Afficher</button>
                     </div>
                     <hr>
+                    <div class="creation-buttons">
+                        <button id="add-chapter-btn">Ajouter un chapitre</button>
+                        <button id="add-item-btn" disabled>Ajouter un sous-élément</button>
+                    </div>
                 </div>
                 <div id="editor-workflow-view" class="hidden">
                     <!-- This will be populated by JavaScript -->


### PR DESCRIPTION
This commit introduces a major refactoring of the wiki's content management and editor functionality.

1.  **Per-Page Content:**
    - The data model in `data/wiki.json` has been migrated from a single `mainContent` to a `pages` object, allowing each navigation item to have its own unique content.
    - The application logic has been updated to load and save content for individual pages.
    - When a new page is created via the editor, it is automatically assigned placeholder content.

2.  **Editor UI Overhaul:**
    - The previous, indirect workflow for creating navigation items has been removed.
    - A new, more direct editing experience has been implemented:
        - Two new buttons, 'Ajouter un chapitre' and 'Ajouter un sous-élément', have been added.
        - Users can now select a parent category directly in the navigation tree to add sub-items to it. - The 'Ajouter un sous-élément' button is contextually disabled (e.g., when no parent is selected, or when the selected parent is a page).
    - The logic for managing the editor state (enabling/disabling selection listeners) has been made more robust.