### PR TITLE
refactor(editor): replace prompts with workflow UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                     <hr>
                     <div class="creation-buttons">
                         <button id="add-chapter-btn">Ajouter un chapitre</button>
-                        <button id="add-item-btn" disabled>Ajouter un sous-élément</button>
+                        <button id="add-item-btn" disabled>éditer un chapitre</button>
                     </div>
                 </div>
                 <div id="editor-workflow-view" class="hidden">


### PR DESCRIPTION
Replaces the use of prompt() and confirm() in the navigation editor with a more user-friendly workflow view.

This new UI provides a 'cascade of choices' for adding new chapters, adding sub-items (pages or categories), and renaming existing items.

The button 'Ajouter un sous-élément' has been renamed to 'éditer un chapitre' as requested.