### PR TITLE
feat: Add image insertion and management features

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -128,6 +128,36 @@ header h1 {
     margin-top: 8px;
 }
 
+.image-container {
+    position: relative;
+    display: inline-block;
+    resize: both;
+    overflow: hidden;
+    border: 1px dashed #ccc;
+}
+
+.image-container img {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.delete-image-btn {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    display: none;
+    background: rgba(0,0,0,0.5);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+.editor-mode .image-container:hover .delete-image-btn {
+    display: block;
+}
+
 /* An 'open' class will be toggled by JS to show the submenu */
 #side-nav .submenu.open {
     display: block;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             </div>
             <div id="edit-toolbar" class="hidden">
                 <button id="insert-table">Ajouter un tableau</button>
+                <button id="insert-image">Ajouter une image</button>
                 <button id="save-button">Sauvegarder</button>
                 <button id="logout-button">Se déconnecter et sauvegarder</button>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -70,6 +70,35 @@ document.addEventListener('DOMContentLoaded', async function() {
         });
     }
 
+    const insertImageBtn = document.getElementById('insert-image');
+    if (insertImageBtn) {
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = 'image/*';
+        fileInput.style.display = 'none';
+        fileInput.addEventListener('change', (event) => {
+            const file = event.target.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    const main = document.getElementById('main-content');
+                    const container = document.createElement('div');
+                    container.className = 'image-container';
+                    const img = document.createElement('img');
+                    img.src = e.target.result;
+                    container.appendChild(img);
+                    main.appendChild(container);
+                    addImageControls(container);
+                    saveWiki();
+                };
+                reader.readAsDataURL(file);
+            }
+        });
+        insertImageBtn.addEventListener('click', () => {
+            fileInput.click();
+        });
+    }
+
     function initializeNavigation() {
         const sideNav = document.getElementById('side-nav');
         if (sideNav.dataset.navListener) return;
@@ -109,6 +138,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             mainContent.addEventListener('input', saveWiki);
         }
         addTableDeleteButtons();
+        addImageControls();
         if (!setupNavSelectionHandler) {
             setupNavSelectionHandler = initializeEditorPanel();
         }
@@ -134,6 +164,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             mainContent.removeEventListener('input', saveWiki);
         }
         document.querySelectorAll('.delete-table-btn').forEach(btn => btn.remove());
+        document.querySelectorAll('.delete-image-btn').forEach(btn => btn.remove());
         if (setupNavSelectionHandler) {
             setupNavSelectionHandler(false);
         }
@@ -538,6 +569,23 @@ document.addEventListener('DOMContentLoaded', async function() {
         });
     }
 
+    function addImageControls(container) {
+        const containers = container ? [container] : document.querySelectorAll('#main-content .image-container');
+        containers.forEach(container => {
+            if (container.querySelector('.delete-image-btn')) return;
+            const btn = document.createElement('button');
+            btn.innerHTML = '&times;';
+            btn.className = 'delete-image-btn';
+            btn.addEventListener('click', () => {
+                if (confirm('Êtes-vous sûr de vouloir supprimer cette image ?')) {
+                    container.remove();
+                    saveWiki();
+                }
+            });
+            container.appendChild(btn);
+        });
+    }
+
     function assignNavIds() {
         const items = document.querySelectorAll('#side-nav li');
         items.forEach((li, index) => {
@@ -677,7 +725,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         if (!currentPageId) return;
         const main = document.getElementById('main-content');
         const clone = main.cloneNode(true);
-        clone.querySelectorAll('.delete-table-btn').forEach(btn => btn.remove());
+        clone.querySelectorAll('.delete-table-btn, .delete-image-btn').forEach(btn => btn.remove());
         wikiPages[currentPageId] = clone.innerHTML;
     }
 


### PR DESCRIPTION
This commit introduces the ability for users to add, resize, and delete images within the main content area of the wiki.

Key changes include:
- An "Ajouter une image" (Add Image) button has been added to the editor toolbar.
- Clicking the button opens a file dialog to select an image.
- The selected image is inserted into the content, wrapped in a resizable container.
- A delete button is available on each image when in editor mode, allowing for its removal.
- The saving mechanism has been updated to handle the new image content while stripping out editor-specific controls.