### PR TITLE
feat: add WoW effect to manual save

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -262,13 +262,20 @@ body.editor-mode #side-nav li:not(.hidden-item) > a {
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.6);
+    background: rgba(10, 2, 2, 0.85);
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     color: #fff;
     z-index: 1000;
+    text-shadow: 0 0 8px #ffdf7e;
+}
+
+#save-overlay p {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: #ffdf7e;
 }
 
 #save-overlay.hidden {
@@ -276,13 +283,26 @@ body.editor-mode #side-nav li:not(.hidden-item) > a {
 }
 
 .spinner {
-    border: 8px solid #f3f3f3;
-    border-top: 8px solid #3498db;
+    position: relative;
+    width: 150px;
+    height: 150px;
+    margin-bottom: 30px;
+}
+
+.spinner::before, .spinner::after {
+    content: '';
+    position: absolute;
     border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    animation: spin 1s linear infinite;
-    margin-bottom: 15px;
+    inset: 0;
+    border: 3px solid transparent;
+    border-top-color: #ffdf7e;
+    animation: spin 2s linear infinite;
+}
+
+.spinner::after {
+    border-top-color: #f7a81b;
+    animation: spin 3s linear infinite reverse;
+    animation-delay: -0.5s;
 }
 
 @keyframes spin {

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
     </div>
     <div id="save-overlay" class="hidden">
         <div class="spinner"></div>
-        <p>Sauvegarde du Wiki en cours...</p>
+        <p>Sauvegarde en ligne du Wiki en cours</p>
     </div>
     <script src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -745,11 +745,17 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
 
     async function saveOnline() {
+        showSaveOverlay();
         try {
             await saveWikiOnline();
-            alert('Sauvegarde manuelle effectuée.');
+            // Adding a small delay to ensure the animation is visible
+            setTimeout(() => {
+                hideSaveOverlay();
+            }, 1500); // 1.5 second delay
         } catch (e) {
+            hideSaveOverlay();
             alert('Erreur lors de la sauvegarde en ligne');
+            console.error(e);
         }
     }
 


### PR DESCRIPTION
This commit introduces a "WoW effect" to the manual save functionality as requested.

- The save overlay has been restyled with a more thematic, darker background, and a stylized, multi-layered spinning circle with golden colors.
- The text in the overlay has been updated to "Sauvegarde en ligne du Wiki en cours" and styled to be more prominent.
- The manual save function in JavaScript now displays this overlay during the save operation and hides it after a short delay, providing better visual feedback to the user and replacing the previous `alert`.