### PR TITLE
Fix(wiki): Repair the saving mechanism for the wiki editor

### DIFF
--- a/netlify/functions/package.json
+++ b/netlify/functions/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "node-fetch": "^2.6.7"
+  }
+}

--- a/netlify/functions/saveWiki.js
+++ b/netlify/functions/saveWiki.js
@@ -1,3 +1,5 @@
+const fetch = require('node-fetch');
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' };
@@ -42,6 +44,15 @@ exports.handler = async (event) => {
     }
 
 
+    const payload = {
+      message: 'Mise à jour wiki.json via Netlify',
+      content,
+    };
+
+    if (sha) {
+      payload.sha = sha;
+    }
+
     const putRes = await fetch(apiUrl, {
       method: 'PUT',
       headers: {
@@ -49,11 +60,7 @@ exports.handler = async (event) => {
         'Content-Type': 'application/json',
         'User-Agent': 'netlify-function-fetch'
       },
-      body: JSON.stringify({
-        message: 'Mise à jour wiki.json via Netlify',
-        content,
-        sha
-      })
+      body: JSON.stringify(payload)
     });
 
     if (!putRes.ok) {


### PR DESCRIPTION
The wiki was failing to save content due to a bug in the `saveWiki.js` Netlify function. The function was not correctly making requests to the GitHub API to update the `data/wiki.json` file.

This was caused by two issues:
1. The Netlify function environment was missing the `node-fetch` module for making server-side API calls.
2. The logic for updating the file via the GitHub API did not explicitly handle the difference between creating a new file (which requires omitting the `sha`) and updating an existing file (which requires the `sha`).

This commit resolves the issue by:
- Adding a `package.json` to the `netlify/functions` directory to include the `node-fetch` dependency.
- Modifying the `saveWiki.js` function to import `node-fetch`.
- Refactoring the function's save logic to conditionally include the `sha` in the payload only when the file is being updated, ensuring compatibility with the GitHub API for both creation and update operations.