### PR TITLE
Add game master navigation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">

--- a/pages/bestiaire.html
+++ b/pages/bestiaire.html
@@ -163,6 +163,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">

--- a/pages/equipement.html
+++ b/pages/equipement.html
@@ -163,6 +163,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">

--- a/pages/personnages.html
+++ b/pages/personnages.html
@@ -163,6 +163,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">

--- a/pages/regles.html
+++ b/pages/regles.html
@@ -163,6 +163,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">

--- a/pages/univers.html
+++ b/pages/univers.html
@@ -163,6 +163,135 @@
                             </ul>
                         </li>
                     </ul>
+                    <h3>POUR LES MAÎTRES DU JEU…</h3>
+                    <ul>
+                        <li>
+                            <span class="category-toggle">L'opposition</span>
+                            <ul class="submenu">
+                                <li><a href="#">Les rencontres</a></li>
+                                <li><a href="#">L'expérience</a></li>
+                                <li><a href="#">Les trésors</a></li>
+                                <li><a href="#">Gemmes et bijoux</a></li>
+                                <li><a href="#">Objets d'art</a></li>
+                                <li><a href="#">Générateur aléatoire de trésors</a></li>
+                                <li><a href="#">Lire le profil des monstres</a></li>
+                                <li><a href="#">Liste alphabétique des monstres</a></li>
+                                <li><a href="#">Familles de monstres</a></li>
+                                <li><a href="#">Types et sous-types de créatures</a></li>
+                                <li><a href="#">Règles de monstres universelles</a></li>
+                                <li><a href="#">Capacités spéciales</a></li>
+                                <li><a href="#">Archétypes de créature</a></li>
+                                <li><a href="#">Galerie de PNJ</a></li>
+                                <li><a href="#">Classes de PNJ</a></li>
+                                <li><a href="#">Apparitions</a></li>
+                                <li><a href="#">Afflictions</a></li>
+                                <li><a href="#">Courses-poursuites</a></li>
+                                <li><a href="#">États préjudiciables</a></li>
+                                <li><a href="#">Plaies magiques (descriptions individuelles)</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les outils de création</span>
+                            <ul class="submenu">
+                                <li><a href="#">Créer une race</a></li>
+                                <li><a href="#">Créer une classe</a></li>
+                                <li><a href="#">Créer un archétype</a></li>
+                                <li><a href="#">Créer une classe de prestige</a></li>
+                                <li><a href="#">Créer ou modifier un monstre</a></li>
+                                <li><a href="#">Créer une créature artificielle</a></li>
+                                <li><a href="#">Créer des PNJ</a></li>
+                                <li><a href="#">Créer un sort</a></li>
+                                <li><a href="#">Créer un monde</a></li>
+                                <li><a href="#">Créer une campagne ouverte</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">L'environnement</span>
+                            <ul class="submenu">
+                                <li><a href="#">Donjons</a></li>
+                                <li><a href="#">Pièges</a></li>
+                                <li><a href="#">Aventures en extérieur</a></li>
+                                <li><a href="#">Milieu aquatique</a></li>
+                                <li><a href="#">Milieu urbain</a></li>
+                                <li><a href="#">Climat</a></li>
+                                <li><a href="#">Plans</a></li>
+                                <li><a href="#">Dangers naturels</a></li>
+                                <li><a href="#">Aventures nautiques</a></li>
+                                <li><a href="#">Catastrophes</a></li>
+                                <li><a href="#">Coût de la vie</a></li>
+                                <li><a href="#">Dangers inhabituels</a></li>
+                                <li><a href="#">Magie primordiale</a></li>
+                                <li><a href="#">Villes et communautés</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Précisions, aides et liens externes</span>
+                            <ul class="submenu">
+                                <li><a href="#">FAQ officielles (site Paizo ↗)</a></li>
+                                <li><a href="#">FAQ non officielle</a></li>
+                                <li><a href="#">Glossaire VO/VF à jour ↗ (archétypes, armes, armures, dons, équipement, monstres, PNJ, sorts, etc.)</a></li>
+                                <li><a href="#">Glossaires obsolètes</a></li>
+                                <li><a href="#">Aides de jeu</a></li>
+                                <li><a href="#">Aperçu de Pathfinder RPG</a></li>
+                                <li><a href="#">Cartes Paizo : Fumbles et Coups Critiques</a></li>
+                                <li><a href="#">Choix des caractéristiques</a></li>
+                                <li><a href="#">Publications relatives à Pathfinder RPG</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span class="category-toggle">Les sous-systèmes</span>
+                            <ul class="submenu">
+                                <li>
+                                    <span class="category-toggle">GC — Gestion de groupe, royaumes, guerre et exploration</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Intermèdes</a></li>
+                                        <li><a href="#">Systèmes de campagne</a></li>
+                                        <li><a href="#">Royaumes et guerre</a></li>
+                                        <li><a href="#">Combat de masse</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AI — Aventures sociales</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Maîtriser l'intrigue</a></li>
+                                        <li><a href="#">Conflits sociaux</a></li>
+                                        <li><a href="#">Duels verbaux</a></li>
+                                        <li><a href="#">Compétences en conflit</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">AO — Aventures occultes</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Mener une partie occulte</a></li>
+                                        <li><a href="#">Règles techniques</a></li>
+                                        <li><a href="#">Récompenses occultes</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">PU — Unchained (systèmes repensés et variantes)</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation</a></li>
+                                        <li><a href="#">Classes unchained</a></li>
+                                        <li><a href="#">Compétences et options unchained</a></li>
+                                        <li><a href="#">Mécanismes de jeu unchained</a></li>
+                                        <li><a href="#">Magie unchained</a></li>
+                                        <li><a href="#">Création de monstres simplifiée</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <span class="category-toggle">CMY — Aventures mythiques</span>
+                                    <ul class="submenu">
+                                        <li><a href="#">Présentation (glossaire mythique)</a></li>
+                                        <li><a href="#">Mener une partie mythique</a></li>
+                                        <li><a href="#">Création d’un personnage mythique</a></li>
+                                        <li><a href="#">Options de personnage mythiques</a></li>
+                                        <li><a href="#">Monstres mythiques</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </nav>
             </aside>
             <main id="main-content">


### PR DESCRIPTION
## Summary
- add "Pour les Maîtres du Jeu…" navigation section with GM-focused resources
- include GM menu across index and all player pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cfc55e548332ae9dd44ce0c30808