### PR TITLE
feat: Add real-time search bar to wiki

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -479,3 +479,53 @@ body.editor-mode #side-nav li:not(.hidden-item) > a {
 .hide-icon:hover {
     color: #107586;
 }
+
+#search-container {
+    position: relative;
+    margin: 10px 0;
+    max-width: 400px; /* Or as needed */
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#search-bar {
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 20px; /* Rounded corners */
+    box-sizing: border-box;
+}
+
+#search-results {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #ccc;
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 1001;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+#search-results a {
+    display: block;
+    padding: 10px 15px;
+    text-decoration: none;
+    color: #333;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+
+#search-results a:last-child {
+    border-bottom: none;
+}
+
+#search-results a:hover {
+    background-color: #f2f2f2;
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
     <div class="container">
         <header>
             <h1>Transcendant WIKI</h1>
+            <div id="search-container">
+                <input type="text" id="search-bar" placeholder="Rechercher dans le wiki...">
+                <div id="search-results"></div>
+            </div>
             <div id="login-area">
                 <div><input type="text" id="login-username" placeholder="Identifiant"></div>
                 <div><input type="password" id="login-password" placeholder="Mot de passe"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     assignNavIds();
     loadHiddenItems();
     initializeNavigation();
+    initializeSearch();
 
     const loginBtn = document.getElementById('login-button');
     if (loginBtn) {
@@ -829,6 +830,62 @@ document.addEventListener('DOMContentLoaded', async function() {
             hidden = hidden.filter(item => item !== id);
         }
         localStorage.setItem('hiddenItems', JSON.stringify(hidden));
+    }
+
+    function initializeSearch() {
+        const searchBar = document.getElementById('search-bar');
+        const searchResults = document.getElementById('search-results');
+
+        if (!searchBar || !searchResults) return;
+
+        searchBar.addEventListener('input', () => {
+            const query = searchBar.value.toLowerCase();
+            searchResults.innerHTML = '';
+
+            if (query.length < 2) {
+                searchResults.style.display = 'none';
+                return;
+            }
+
+            const allNavLinks = Array.from(document.querySelectorAll('#side-nav a'));
+            const results = [];
+
+            allNavLinks.forEach(link => {
+                const li = link.closest('li');
+                const pageId = li.dataset.id;
+                const title = link.textContent.toLowerCase();
+                const content = (wikiPages[pageId] || '').toLowerCase();
+
+                if (title.includes(query) || content.includes(query)) {
+                    results.push({ id: pageId, title: link.textContent });
+                }
+            });
+
+            if (results.length > 0) {
+                results.forEach(result => {
+                    const resultItem = document.createElement('a');
+                    resultItem.href = '#';
+                    resultItem.textContent = result.title;
+                    resultItem.dataset.id = result.id;
+                    resultItem.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        loadPage(result.id);
+                        searchResults.style.display = 'none';
+                        searchBar.value = '';
+                    });
+                    searchResults.appendChild(resultItem);
+                });
+                searchResults.style.display = 'block';
+            } else {
+                searchResults.style.display = 'none';
+            }
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!searchResults.contains(e.target) && e.target !== searchBar) {
+                searchResults.style.display = 'none';
+            }
+        });
     }
 });
 


### PR DESCRIPTION
This commit introduces a real-time search bar to the wiki.

- Adds a search input and results container to `index.html`.
- Implements the search logic in `js/main.js`:
  - An event listener on the search bar triggers a search on input.
  - The search function filters both page titles and content from the `wikiPages` object.
  - Matching results are displayed in a dropdown list.
  - Clicking a result navigates to the corresponding page.
- Adds CSS styles in `css/style.css` for the search bar and the results dropdown to ensure a clean and integrated look.